### PR TITLE
Support variety item view type for Section

### DIFF
--- a/heterogeneousadapter/src/main/java/com/marverenic/adapter/HeterogeneousAdapter.java
+++ b/heterogeneousadapter/src/main/java/com/marverenic/adapter/HeterogeneousAdapter.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Implementation of {@link android.support.v7.widget.RecyclerView.Adapter} designed for data sets
@@ -16,7 +17,7 @@ import java.util.List;
  * exception that they may only have one type of view. Sections may be implemented similarly to
  * extending {@link android.support.v7.widget.RecyclerView.Adapter}, or existing implementations
  * including {@link ListSection} {@link SingletonSection} may be used instead.
- *
+ * <p>
  * To populate this adapter, use {@link #addSection(Section)}. All data lookup and ViewHolder
  * instantiation is handled by Sections. Sections appear one after another in the order that they
  * are added, and may be positioned relative to other sections using
@@ -28,14 +29,21 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
 
     private static final long EMPTY_STATE_ID = -2;
 
+    public static final int ITEM_TYPE_UNDEFINED = Integer.MIN_VALUE;
+    public static final int MIN_ITEM_TYPE_VALUE = 0;
+    public static final int MAX_ITEM_TYPE_VALUE = 99;
+
+    private static final int MULTIPLIER = MAX_ITEM_TYPE_VALUE + 1;
+
     /**
      * Used in {@link #getItemViewType(int)} to denote that the empty state should be shown
      */
     private static final int EMPTY_TYPE = -2;
 
     private List<Section> mSections;
-    private SparseArray<Section> mSectionIdMap;
+    private SparseArray<Section> mSectionTypeMap;
     private EmptyState mEmptyState;
+    private boolean mShareItemType;
 
     /**
      * The number of times {@link #addSection(Section)} and {@link #addSection(Section, int)} have
@@ -51,13 +59,25 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
     private Coordinate mCoordinate;
 
     /**
-     * Sets up a new HeterogeneousAdapter with no children
+     * Sets up a new HeterogeneousAdapter with no children and disable <code>shareItemType</code>
+     * by default.
      */
     public HeterogeneousAdapter() {
+        this(false);
+    }
+
+    /**
+     * Sets up a new HeterogeneousAdapter with no children
+     *
+     * @param shareItemType set true if a {@link Section} can reuse <code>ViewHolder</code> with the same <code>itemType</code>
+     *                      returned from another section.
+     */
+    public HeterogeneousAdapter(boolean shareItemType) {
         mSections = new ArrayList<>();
-        mSectionIdMap = new SparseArray<>();
+        mSectionTypeMap = new SparseArray<>();
         mCoordinate = new Coordinate();
         mSectionBindingCount = 0;
+        mShareItemType = shareItemType;
     }
 
     /**
@@ -72,7 +92,16 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
     }
 
     /**
+     * @return Return true if a {@link Section} can reuse <code>ViewHolder</code> with the same <code>itemType</code>
+     * returned from another section. This value is immutable.
+     */
+    public boolean isShareItemType() {
+        return mShareItemType;
+    }
+
+    /**
      * Adds a {@link HeterogeneousAdapter.Section} to the bottom of this Adapter
+     *
      * @param section the Section to add
      * @return this Adapter, for chain building
      */
@@ -82,25 +111,31 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
 
     /**
      * Adds a {@link HeterogeneousAdapter.Section} to a specified index in this Adapter
+     *
      * @param section the Section to add
-     * @param index the index to add this Section at
+     * @param index   the index to add this Section at
      * @return this Adapter, for chain building
      */
     public HeterogeneousAdapter addSection(@NonNull Section section, int index) {
-        section.setTypeId(getNextSectionId());
+        section.setSectionId(getNextSectionId());
         mSections.add(index, section);
-        mSectionIdMap.put(section.getTypeId(), section);
         notifyDataSetChanged();
         return this;
     }
 
     /**
      * Removes a section in a specified index
+     *
      * @param index the index to remove
      */
     public void removeSection(int index) {
         Section removed = mSections.remove(index);
-        mSectionIdMap.remove(removed.getTypeId());
+        for (int i = 0; i < mSectionTypeMap.size(); i++) {
+            int key = mSectionTypeMap.keyAt(i);
+            if (removed == mSectionTypeMap.get(key)) {
+                mSectionTypeMap.remove(key);
+            }
+        }
         notifyDataSetChanged();
     }
 
@@ -108,6 +143,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
      * Sets the {@link EmptyState} to be displayed when there are no views to otherwise be displayed
      * in this Adapter. This may occur either because no data has been loaded (and all Sections are
      * empty), or because no Sections have been added.
+     *
      * @param emptyState The empty state to show when there are no items to be shown in this list
      *                   {@code null} to disable showing an empty state when the Adapter is empty,
      *                   and to keep it completely blank.
@@ -121,7 +157,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
      * returns two values into the provided {@code Coordinate} so that it can be reused to save GC
      * overhead.
      *
-     * @param position The position in the entire data set to lookup a coordinate of
+     * @param position   The position in the entire data set to lookup a coordinate of
      * @param coordinate {@code Coordinate} object to put the result into
      */
     protected final void lookupCoordinates(int position, Coordinate coordinate) {
@@ -140,18 +176,26 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
 
     /**
      * Calculates the number of views contained in sections proceeding a given section
-     * @param typeId The ID of the section to get the leading view count of
+     *
      * @return The number of views in this list that are above the first view in the given section
      */
-    protected int getLeadingViewCount(int typeId) {
+    protected int getLeadingViewCount(Section section) {
         int count = 0;
-        for (Section section : mSections) {
-            if (section.getTypeId() == typeId) {
+        for (Section _section : mSections) {
+            if (_section == section) {
                 break;
             }
-            count += section.getItemCount(this);
+            count += _section.getItemCount(this);
         }
         return count;
+    }
+
+    private int zipItemType(int sectionId, int itemType) {
+        return sectionId * MULTIPLIER + itemType;
+    }
+
+    private int unzipItemType(int sectionId, int zippedNumber) {
+        return zippedNumber - sectionId * MULTIPLIER;
     }
 
     @Override
@@ -161,8 +205,27 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
         }
 
         lookupCoordinates(position, mCoordinate);
-        int section = mCoordinate.getSection();
-        return mSections.get(section).getTypeId();
+        int sectionIndex = mCoordinate.getSection();
+        Section section = mSections.get(sectionIndex);
+
+        int givenItemType = section.getItemType(mCoordinate.getItemIndex());
+
+        if (isShareItemType()) {
+            mSectionTypeMap.put(givenItemType, section);
+            return givenItemType;
+        } else {
+            // check if given itemType is valid
+            if ((givenItemType != ITEM_TYPE_UNDEFINED)
+                    && (givenItemType < MIN_ITEM_TYPE_VALUE || givenItemType > MAX_ITEM_TYPE_VALUE)) {
+                String error = String.format(Locale.US, "Invalid itemType at position %d of section %d: " +
+                        "itemType must be between %d and %d", position, sectionIndex,
+                        MIN_ITEM_TYPE_VALUE, MAX_ITEM_TYPE_VALUE);
+                throw new IllegalStateException(error);
+            }
+            int itemType = zipItemType(section.getSectionId(), givenItemType);
+            mSectionTypeMap.put(itemType, section);
+            return itemType;
+        }
     }
 
     @Override
@@ -176,7 +239,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
         int item = mCoordinate.getItemIndex();
 
         int givenId = mSections.get(section).getId(item);
-        int sectionId = mSections.get(section).getTypeId();
+        int sectionId = mSections.get(section).getSectionId();
 
         if (givenId == NO_ID) {
             return RecyclerView.NO_ID;
@@ -185,12 +248,23 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
         }
     }
 
+    protected Section getSectionByViewType(int viewType) {
+        return mSectionTypeMap.get(viewType);
+    }
+
     @Override
     public EnhancedViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         if (viewType == EMPTY_TYPE) {
             return mEmptyState.createViewHolder(this, parent);
         }
-        return mSectionIdMap.get(viewType).createViewHolder(this, parent);
+        Section section = mSectionTypeMap.get(viewType);
+        if (!isShareItemType()) {
+            // get real itemType
+            int itemType = unzipItemType(section.getSectionId(), viewType);
+            return section.createViewHolder(this, parent, itemType);
+        } else {
+            return section.createViewHolder(this, parent, viewType);
+        }
     }
 
     @Override
@@ -236,9 +310,10 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
     /**
      * Gets the index of a section in this adapter. Equality is checked using the implementation of
      * {@link Object#equals(Object)}, which defaults to checking references
+     *
      * @param section The section to lookup an index for
      * @return The index of this section relative to other sections in the adapter, or {@code -1}
-     *         if it wasn't found in this adapter.
+     * if it wasn't found in this adapter.
      */
     public int getSectionIndex(Section<?> section) {
         for (int i = 0; i < mSections.size(); i++) {
@@ -251,6 +326,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
 
     /**
      * Gets the section at a given index
+     *
      * @param index The index to get the attached section of
      * @return The section at the specified index
      */
@@ -262,26 +338,28 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
      * Holds a group of sequential items if the same type to be displayed in a
      * {@link HeterogeneousAdapter}. Sections act as {@link RecyclerView.Adapter}s with the
      * condition that they may only have one type of ItemView
+     *
      * @param <Type> The type of data that this Section holds
      * @see HeterogeneousAdapter.ListSection
      * @see HeterogeneousAdapter.SingletonSection
      */
     public static abstract class Section<Type> {
-
-        private int mTypeId;
+        private int mSectionId;
 
         /**
          * Creates a ViewHolder for the {@link HeterogeneousAdapter} this Section is attached to
+         *
          * @param adapter the Adapter requesting a new ViewHolder
-         * @param parent the ViewGroup that this ViewHolder will be placed into
+         * @param parent  the ViewGroup that this ViewHolder will be placed into
          * @return A valid ViewHolder that may be used for items in this Section
          * @see RecyclerView.Adapter#createViewHolder(ViewGroup, int)
          */
         public abstract EnhancedViewHolder<Type> createViewHolder(HeterogeneousAdapter adapter,
-                                                                  ViewGroup parent);
+                                                                  ViewGroup parent, int itemType);
 
         /**
          * Get the ID of an item in the data set
+         *
          * @param position The index in the data set that an ID has been requested for
          * @return The ID of this item or {@link RecyclerView#NO_ID}
          * @see RecyclerView.Adapter#getItemId(int)
@@ -293,6 +371,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
         /**
          * Override this method to hide this Section if its visibility is dependent on another
          * external condition. The default implementation always shows this section.
+         *
          * @param adapter The adapter this Section is attached to
          * @return true if this section should be shown, false if it should be hidden
          */
@@ -304,6 +383,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
          * Gets the number of visible items held by this section. This value handles hiding this
          * section with {@link #showSection(HeterogeneousAdapter)}, and will return either
          * {@link #getItemCount()} or {@code 0}.
+         *
          * @param adapter The adapter that this section is attached to
          * @return The number of visible items that are held by this section
          */
@@ -313,43 +393,60 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
 
         /**
          * Gets the number of items held by this section
+         *
          * @return The number of items in this section's backing data set
          */
         public abstract int getItemCount(HeterogeneousAdapter adapter);
 
         /**
          * Returns an item in the data set used to populate a ViewHolder
+         *
          * @param position The index of the item to return
          * @return The item at the specified index in this Section's data set
          */
         public abstract Type get(int position);
 
         /**
-         * Used internally by {@link HeterogeneousAdapter} to set a unique ID for this section.
-         * @param id The ID to use for this Section when {@link RecyclerView} calls
-         *           {@link RecyclerView.Adapter#getItemViewType(int)}
+         * Get the item type at <code>position</code> used to create ViewHolder. This method works like
+         * {@link RecyclerView.Adapter#getItemViewType(int)}.
+         * <p>
+         * The return value must be {@link #ITEM_TYPE_UNDEFINED} or between range
+         * {@link #MIN_ITEM_TYPE_VALUE} and {@link #MAX_ITEM_TYPE_VALUE} (inclusive).
+         * </p>
+         * Default implementation return {@link #ITEM_TYPE_UNDEFINED}.
+         *
+         * @param position The index of item in this section.
+         * @return The item type.
          */
-        private void setTypeId(int id) {
-            mTypeId = id;
+        public int getItemType(int position) {
+            return ITEM_TYPE_UNDEFINED;
         }
 
         /**
-         * @return The item type ID as used by
-         *         {@link RecyclerView.Adapter#getItemViewType(int)}. This ID is constant
-         *         for all items in this section. This value should be unique and constant
-         *         to the each class that extends Section. This value MUST be unique among
-         *         all Sections that are put in the same HeterogeneousAdapter.
+         * Used internally by {@link HeterogeneousAdapter} to set a unique ID for this section.
+         * This Id is used for calculating unique itemType to return in function
+         * {@link RecyclerView.Adapter#getItemViewType(int)}.
+         *
+         * @param sectionId Unique section ID.
          */
-        public final int getTypeId() {
-            return mTypeId;
+        private void setSectionId(int sectionId) {
+            mSectionId = sectionId;
+        }
+
+        /**
+         * @return the unique ID of this section.
+         */
+        private int getSectionId() {
+            return mSectionId;
         }
     }
 
     /**
      * An extension of {@link HeterogeneousAdapter.Section} that always has exactly one item in
      * the set
+     *
      * @param <Type> The class of the item that this Section shows. You may use {@link Void}
-     *              if this Section has no data
+     *               if this Section has no data
      */
     public static abstract class SingletonSection<Type> extends Section<Type> {
 
@@ -365,6 +462,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
         /**
          * Replace the current data item. Callers are responsible for calling
          * {@link RecyclerView.Adapter#notifyDataSetChanged()} or an equivalent method
+         *
          * @param data The new data item to show in this Section
          */
         public void setData(Type data) {
@@ -386,6 +484,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
     /**
      * An extension of {@link HeterogeneousAdapter.Section} used to show a list of items of the
      * same type
+     *
      * @param <Type> The class of the data that this Section shows.
      */
     public static abstract class ListSection<Type> extends Section<Type> {
@@ -409,6 +508,7 @@ public class HeterogeneousAdapter extends RecyclerView.Adapter<EnhancedViewHolde
         /**
          * Replace the active data set. Callers are responsible for calling
          * {@link RecyclerView.Adapter#notifyDataSetChanged()}
+         *
          * @param mData The new data set to back this Section
          */
         public void setData(@NonNull List<Type> mData) {

--- a/sample/src/main/java/com/marverenic/demo/heterogeneous/MainActivity.java
+++ b/sample/src/main/java/com/marverenic/demo/heterogeneous/MainActivity.java
@@ -6,9 +6,10 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
-import com.marverenic.adapter.HeterogeneousAdapter;
+import com.marverenic.adapter.DragDropAdapter;
 import com.marverenic.demo.heterogeneous.section.DynamicEntrySection;
 import com.marverenic.demo.heterogeneous.section.DynamicHeaderSection;
+import com.marverenic.demo.heterogeneous.section.VarietyTypeAndDraggableSection;
 import com.marverenic.demo.heterogeneous.section.EntrySection;
 import com.marverenic.demo.heterogeneous.section.HeaderSection;
 import com.marverenic.demo.heterogeneous.section.TextSection;
@@ -19,7 +20,7 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
 
-    private HeterogeneousAdapter mAdapter;
+    private DragDropAdapter mAdapter;
 
     private List<String> mDynamicEntries;
     private int mDynamicCount;
@@ -31,7 +32,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         setContentView(R.layout.activity_main);
 
         RecyclerView mRecyclerView = (RecyclerView) findViewById(R.id.list);
-        mAdapter = new HeterogeneousAdapter();
+        mAdapter = new DragDropAdapter();
 
         mDynamicEntries = new ArrayList<>(Arrays.asList("Entry 1", "Entry 2"));
         mDynamicCount = mDynamicEntries.size();
@@ -43,11 +44,18 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         mAdapter.addSection(new DynamicHeaderSection("Dynamic entries", mDynamicEntries));
         mAdapter.addSection(new DynamicEntrySection(mDynamicEntries));
+
+        mAdapter.addSection(new HeaderSection("Variety type and draggable section"));
+        mAdapter.setDragSection(new VarietyTypeAndDraggableSection(new ArrayList<>(Arrays.asList(
+                "Red", "Blue", "Red", "Blue"))));
+
+
         mAdapter.addSection(new HeaderSection("Footer"));
         mAdapter.addSection(new TextSection(getString(R.string.message_footer)));
 
         mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
-        mRecyclerView.setAdapter(mAdapter);
+
+        mAdapter.attach(mRecyclerView);
 
         findViewById(R.id.add_button).setOnClickListener(this);
     }

--- a/sample/src/main/java/com/marverenic/demo/heterogeneous/section/DynamicEntrySection.java
+++ b/sample/src/main/java/com/marverenic/demo/heterogeneous/section/DynamicEntrySection.java
@@ -23,7 +23,7 @@ public class DynamicEntrySection extends HeterogeneousAdapter.ListSection<String
 
     @Override
     public EnhancedViewHolder<String> createViewHolder(HeterogeneousAdapter adapter,
-                                                       ViewGroup parent) {
+                                                       ViewGroup parent, int itemType) {
         return ViewHolder.create(adapter, getData(), parent);
     }
 

--- a/sample/src/main/java/com/marverenic/demo/heterogeneous/section/EntrySection.java
+++ b/sample/src/main/java/com/marverenic/demo/heterogeneous/section/EntrySection.java
@@ -20,7 +20,7 @@ public class EntrySection extends HeterogeneousAdapter.ListSection<String> {
 
     @Override
     public EnhancedViewHolder<String> createViewHolder(HeterogeneousAdapter adapter,
-                                                       ViewGroup parent) {
+                                                       ViewGroup parent, int itemType) {
         return ViewHolder.create(parent);
     }
 

--- a/sample/src/main/java/com/marverenic/demo/heterogeneous/section/HeaderSection.java
+++ b/sample/src/main/java/com/marverenic/demo/heterogeneous/section/HeaderSection.java
@@ -17,7 +17,7 @@ public class HeaderSection extends HeterogeneousAdapter.SingletonSection<String>
 
     @Override
     public EnhancedViewHolder<String> createViewHolder(HeterogeneousAdapter adapter,
-                                                       ViewGroup parent) {
+                                                       ViewGroup parent, int itemType) {
         return ViewHolder.create(parent);
     }
 

--- a/sample/src/main/java/com/marverenic/demo/heterogeneous/section/TextSection.java
+++ b/sample/src/main/java/com/marverenic/demo/heterogeneous/section/TextSection.java
@@ -17,7 +17,7 @@ public class TextSection extends HeterogeneousAdapter.SingletonSection<String> {
 
     @Override
     public EnhancedViewHolder<String> createViewHolder(HeterogeneousAdapter adapter,
-                                                     ViewGroup parent) {
+                                                     ViewGroup parent, int itemType) {
         return ViewHolder.create(parent);
     }
 

--- a/sample/src/main/java/com/marverenic/demo/heterogeneous/section/VarietyTypeAndDraggableSection.java
+++ b/sample/src/main/java/com/marverenic/demo/heterogeneous/section/VarietyTypeAndDraggableSection.java
@@ -1,0 +1,79 @@
+package com.marverenic.demo.heterogeneous.section;
+
+import android.graphics.Color;
+import android.support.annotation.NonNull;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.marverenic.adapter.DragDropAdapter;
+import com.marverenic.adapter.EnhancedViewHolder;
+import com.marverenic.adapter.HeterogeneousAdapter;
+import com.marverenic.demo.heterogeneous.R;
+
+import java.util.List;
+
+/**
+ * Created by Khang NT on 7/5/17.
+ * Email: khang.neon.1997@gmail.com
+ */
+
+public class VarietyTypeAndDraggableSection extends DragDropAdapter.ListDragSection<String> {
+
+    private static final int TYPE_RED = 1;
+    private static final int TYPE_BLUE = 2;
+
+    public VarietyTypeAndDraggableSection(@NonNull List<String> data) {
+        super(data);
+    }
+
+    @Override
+    public int getItemType(int position) {
+        return "red".equalsIgnoreCase(get(position)) ? TYPE_RED : TYPE_BLUE;
+    }
+
+    @Override
+    public EnhancedViewHolder<String> createViewHolder(HeterogeneousAdapter adapter, ViewGroup parent, int itemType) {
+        int color;
+        if (itemType == TYPE_RED) {
+            color = Color.RED;
+        } else if (itemType == TYPE_BLUE) {
+            color = Color.BLUE;
+        } else {
+            throw new IllegalArgumentException("Invalid item type: " + itemType);
+        }
+        return ViewHolder.create(parent, color);
+    }
+
+    @Override
+    public int getDragHandleId() {
+        return R.id.dragView;
+    }
+
+    @Override
+    protected void onDrop(int from, int to) {
+        // does nothing
+    }
+
+    private static class ViewHolder extends EnhancedViewHolder<String> {
+
+        private TextView mTextView;
+
+        public ViewHolder(View itemView, int color) {
+            super(itemView);
+            mTextView = (TextView) itemView.findViewById(R.id.itemText);
+            mTextView.setTextColor(color);
+        }
+
+        public static ViewHolder create(ViewGroup parent, int color) {
+            return new ViewHolder(LayoutInflater.from(parent.getContext())
+                            .inflate(R.layout.item_entry_draggable, parent, false), color);
+        }
+
+        @Override
+        public void onUpdate(String item, int position) {
+            mTextView.setText(item);
+        }
+    }
+}

--- a/sample/src/main/res/drawable/ic_drag_handle_black_24dp.xml
+++ b/sample/src/main/res/drawable/ic_drag_handle_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,9H4v2h16V9zM4,15h16v-2H4v2z"/>
+</vector>

--- a/sample/src/main/res/layout/item_entry_draggable.xml
+++ b/sample/src/main/res/layout/item_entry_draggable.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="56dp"
+    android:orientation="horizontal"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
+
+    <TextView
+        android:id="@+id/itemText"
+        style="@style/Base.TextAppearance.AppCompat.Subhead"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        tools:text="Item 1"/>
+
+    <ImageView
+        android:id="@+id/dragView"
+        android:layout_width="35dp"
+        android:layout_height="35dp"
+        android:layout_gravity="center_vertical"
+        android:src="@drawable/ic_drag_handle_black_24dp"/>
+
+</LinearLayout>


### PR DESCRIPTION
`HeterogeneousAdapter` reduce a lot of effort when handle many data types within `RecyclerView.Adapter`. As I understand, `HeterogeneousAdapter` assumed that each data model have only one item view type, in other words that mean each `Section` handle one `itemViewType`. 

It becomes a limitation, this is a simple example: How to design `ListSection<ChatData>` for a chat box which display incoming/outgoing message on different side (left/right). It prefer to use different layout for incoming/outgoing message, but `ListSection` only can handle one view type.

I have a small modification, that allow `Section`s to have variety `itemViewType`. Is it reasonable?